### PR TITLE
feat: add CSV format to server list output options

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -33,6 +33,7 @@
         - DeriveGeneric
         - DerivingVia
         - FlexibleContexts
+        - LambdaCase
         - OverloadedRecordDot
         - OverloadedStrings
         - QuasiQuotes

--- a/package.yaml
+++ b/package.yaml
@@ -26,6 +26,7 @@ library:
     - autodocodec
     - autodocodec-schema
     - bytestring
+    - cassava
     - conduit
     - format-numbers
     - githash
@@ -42,6 +43,7 @@ library:
     - time
     - typed-process
     - unordered-containers
+    - vector
     - yaml
 
 executables:

--- a/src/Clompse/Programs/ListServers.hs
+++ b/src/Clompse/Programs/ListServers.hs
@@ -12,11 +12,16 @@ import qualified Clompse.Providers.Aws as Providers.Aws
 import qualified Clompse.Providers.Do as Providers.Do
 import qualified Clompse.Providers.Hetzner as Providers.Hetzner
 import Clompse.Types (Server)
+import qualified Clompse.Types as Types
 import Control.Monad.Except (runExceptT)
 import Control.Monad.IO.Class (MonadIO (..))
 import qualified Data.Aeson as Aeson
+import qualified Data.Csv as Cassava
+import Data.Int (Int16, Int32)
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
+import qualified Data.Time as Time
+import qualified Data.Vector as V
 import GHC.Generics (Generic)
 import qualified System.IO
 import qualified Zamazingo.Text as Z.Text
@@ -91,3 +96,97 @@ listServersForCloudConnection (CloudConnectionHetzner conn) = do
 _log :: MonadIO m => T.Text -> m ()
 _log =
   liftIO . TIO.hPutStrLn System.IO.stderr
+
+
+type ServerList = [ServerListItem]
+
+
+data ServerListItem = ServerListItem
+  { _serverListItemProfile :: !T.Text
+  , _serverListItemProvider :: !Types.Provider
+  , _serverListItemRegion :: !T.Text
+  , _serverListItemId :: !T.Text
+  , _serverListItemName :: !(Maybe T.Text)
+  , _serverListItemState :: !Types.State
+  , _serverListItemCpu :: !(Maybe Int16)
+  , _serverListItemRam :: !(Maybe Int32)
+  , _serverListItemDisk :: !(Maybe Int32)
+  , _serverListItemType :: !(Maybe T.Text)
+  , _serverListItemCreatedAt :: !(Maybe Time.UTCTime)
+  }
+  deriving (Eq, Generic, Show)
+  deriving (Aeson.FromJSON, Aeson.ToJSON) via (ADC.Autodocodec ServerListItem)
+
+
+instance ADC.HasCodec ServerListItem where
+  codec =
+    _codec ADC.<?> "Server List Item"
+    where
+      _codec =
+        ADC.object "ServerListItem" $
+          ServerListItem
+            <$> ADC.requiredField "profile" "Name of the cloud profile." ADC..= _serverListItemProfile
+            <*> ADC.requiredField "provider" "Provider of the server." ADC..= _serverListItemProvider
+            <*> ADC.requiredField "region" "Region of the server." ADC..= _serverListItemRegion
+            <*> ADC.requiredField "id" "ID of the server." ADC..= _serverListItemId
+            <*> ADC.optionalField "name" "Name of the server." ADC..= _serverListItemName
+            <*> ADC.requiredField "state" "State of the server." ADC..= _serverListItemState
+            <*> ADC.optionalField "cpu" "CPU of the server." ADC..= _serverListItemCpu
+            <*> ADC.optionalField "ram" "RAM of the server." ADC..= _serverListItemRam
+            <*> ADC.optionalField "disk" "Disk of the server." ADC..= _serverListItemDisk
+            <*> ADC.optionalField "type" "Type of the server." ADC..= _serverListItemType
+            <*> ADC.optionalField "created_at" "Creation time of the server." ADC..= _serverListItemCreatedAt
+
+
+instance Cassava.ToNamedRecord ServerListItem where
+  toNamedRecord ServerListItem {..} =
+    Cassava.namedRecord
+      [ "profile" Cassava..= _serverListItemProfile
+      , "provider" Cassava..= Types.providerCode _serverListItemProvider
+      , "region" Cassava..= _serverListItemRegion
+      , "id" Cassava..= _serverListItemId
+      , "name" Cassava..= _serverListItemName
+      , "state" Cassava..= Types.stateCode _serverListItemState
+      , "cpu" Cassava..= _serverListItemCpu
+      , "ram" Cassava..= _serverListItemRam
+      , "disk" Cassava..= _serverListItemDisk
+      , "type" Cassava..= _serverListItemType
+      , "created_at" Cassava..= fmap Z.Text.tshow _serverListItemCreatedAt
+      ]
+
+
+instance Cassava.DefaultOrdered ServerListItem where
+  headerOrder _ =
+    V.fromList
+      [ "profile"
+      , "provider"
+      , "region"
+      , "id"
+      , "name"
+      , "state"
+      , "cpu"
+      , "ram"
+      , "disk"
+      , "type"
+      , "created_at"
+      ]
+
+
+toServerList :: ListServersResult -> ServerList
+toServerList ListServersResult {..} =
+  fmap (go _listServersResultProfile) _listServersResultServers
+  where
+    go p Types.Server {..} =
+      ServerListItem
+        { _serverListItemProfile = p
+        , _serverListItemProvider = _serverProvider
+        , _serverListItemRegion = _serverRegion
+        , _serverListItemId = _serverId
+        , _serverListItemName = _serverName
+        , _serverListItemState = _serverState
+        , _serverListItemCpu = _serverCpu
+        , _serverListItemRam = _serverRam
+        , _serverListItemDisk = _serverDisk
+        , _serverListItemType = _serverType
+        , _serverListItemCreatedAt = _serverCreatedAt
+        }


### PR DESCRIPTION
We now have three options:

1. Console (as an ASCII table)
2. CSV
3. JSON
