### PR TITLE
fix(deps): upgrade table-layout to v1.0.0.0

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -61,6 +61,7 @@ let
     overrides = self: super: {
       bytehash = pkgs.haskell.lib.dontCheck super.bytehash;
       hetzner = self.hetzner_0_6_0_0;
+      table-layout = self.callCabal2nixWithOptions "table-layout" sources.table-layout "--no-check" { };
     };
   };
 

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -10,5 +10,12 @@
         "type": "tarball",
         "url": "https://github.com/NixOS/nixpkgs/archive/8468b0786c4f5a4e5eab5a4921b75a0139b0474d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "table-layout": {
+        "sha256": "0vbz8lmjzxz9flpnzjfhis85ck3q6zfn6xa1ms8j5gcgh1bfjilr",
+        "type": "tarball",
+        "url": "https://hackage.haskell.org/package/table-layout-1.0.0.0/table-layout-1.0.0.0.tar.gz",
+        "url_template": "https://hackage.haskell.org/package/table-layout-<version>/table-layout-<version>.tar.gz",
+        "version": "1.0.0.0"
     }
 }

--- a/src/Clompse/Cli.hs
+++ b/src/Clompse/Cli.hs
@@ -201,7 +201,7 @@ doServerListConsole rs =
         ]
       hs =
         Tab.titlesH
-          [ "#"
+          [ "#" :: String
           , "Profile"
           , "Provider"
           , "Region"
@@ -232,7 +232,8 @@ doServerListConsole rs =
           , T.intercalate "," (fmap Z.Net.ipv4ToText (_serverListItemIPv4Static <> _serverListItemIPv4Public))
           ]
       rows = fmap (uncurry mkRows) (zip [1 :: Int ..] rs)
-   in putStrLn $ Tab.tableString cs Tab.unicodeS hs rows
+      table = Tab.columnHeaderTableS cs Tab.unicodeS hs rows
+   in putStrLn $ Tab.tableString table
 
 
 formatIntegral :: Integral a => a -> T.Text


### PR DESCRIPTION
Currently, we are on nixpkgs release v23.11. This package set has table-layout v0.9.1.0. It worked fine so far under Nix shell.

However, when I cut the release v0.0.2, our `build-static.sh` script has failed because table-layout v0.9.1.0 does not support GHC 9.4.8 that both our Nix setup and `build-static.sh` script use. Somehow, Nix does not complain about it.

I have now upgraded table-layout dependency to v1.0.0.0 which satisfies both Nix and vanilla cabal setups (after generating cabal freeze file inside Nix).
