### PR TITLE
fix: add AWS EC2 instance memory and storage size

### DIFF
--- a/src/Clompse/Programs/ListServers.hs
+++ b/src/Clompse/Programs/ListServers.hs
@@ -78,7 +78,7 @@ listServersForCloudConnection (CloudConnectionAws conn) = do
   serversLightsail <- case eServersLightsail of
     Left e -> _log ("    ERROR (AWS Lightsail): " <> Z.Text.tshow e) >> pure []
     Right servers -> pure servers
-  pure (fmap (uncurry Providers.ec2InstanceToServer) serversEc2 <> fmap (uncurry Providers.lightsailInstanceToServer) serversLightsail)
+  pure (fmap Providers.ec2InstanceToServer serversEc2 <> fmap (uncurry Providers.lightsailInstanceToServer) serversLightsail)
 listServersForCloudConnection (CloudConnectionDo conn) = do
   eServers <- runExceptT (Providers.Do.doListDroplets conn)
   case eServers of


### PR DESCRIPTION
1. The storage is only for instance storage.
2. The AWS module gets uglier. I should switch entirely to lens usage.
