### PR TITLE
feat: attach firewall information to servers

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -19,6 +19,7 @@ library:
     - '-Wunused-packages'
   dependencies:
     - aeson
+    - aeson-combinators
     - amazonka
     - amazonka-core
     - amazonka-ec2

--- a/src/Clompse/Programs/ListServers.hs
+++ b/src/Clompse/Programs/ListServers.hs
@@ -116,6 +116,7 @@ data ServerListItem = ServerListItem
   , _serverListItemIPv6Static :: ![Z.Net.IPv6]
   , _serverListItemIPv6Public :: ![Z.Net.IPv6]
   , _serverListItemIPv6Private :: ![Z.Net.IPv6]
+  , _serverListItemFirewalls :: ![Types.Firewall]
   }
   deriving (Eq, Generic, Show)
   deriving (Aeson.FromJSON, Aeson.ToJSON) via (ADC.Autodocodec ServerListItem)
@@ -145,6 +146,7 @@ instance ADC.HasCodec ServerListItem where
             <*> ADC.requiredField "ipv6_static" "Ptatic IPv6 addresses." ADC..= _serverListItemIPv6Static
             <*> ADC.requiredField "ipv6_public" "Public IPv6 addresses." ADC..= _serverListItemIPv6Public
             <*> ADC.requiredField "ipv6_private" "Private IPv6 addresses." ADC..= _serverListItemIPv6Private
+            <*> ADC.requiredField "firewalls" "Firewall configurations." ADC..= _serverListItemFirewalls
 
 
 instance Cassava.ToNamedRecord ServerListItem where
@@ -218,6 +220,7 @@ toServerList ListServersResult {..} =
         , _serverListItemIPv6Static = _serverIpInfoStaticIpv6 _serverIpInfo
         , _serverListItemIPv6Public = _serverIpInfoPublicIpv6 _serverIpInfo
         , _serverListItemIPv6Private = _serverIpInfoPrivateIpv6 _serverIpInfo
+        , _serverListItemFirewalls = _serverFirewalls
         }
 
 

--- a/src/Clompse/Types.hs
+++ b/src/Clompse/Types.hs
@@ -125,6 +125,7 @@ data Server = Server
   , _serverRegion :: !T.Text
   , _serverType :: !(Maybe T.Text)
   , _serverIpInfo :: !ServerIpInfo
+  , _serverFirewalls :: ![Firewall]
   }
   deriving (Eq, Generic, Show)
   deriving (Aeson.FromJSON, Aeson.ToJSON) via (ADC.Autodocodec Server)
@@ -148,6 +149,7 @@ instance ADC.HasCodec Server where
             <*> ADC.requiredField "region" "Region." ADC..= _serverRegion
             <*> ADC.optionalField "type" "Server type." ADC..= _serverType
             <*> ADC.requiredField "ip_info" "Server IP addresses information." ADC..= _serverIpInfo
+            <*> ADC.requiredField "firewalls" "Firewall configurations." ADC..= _serverFirewalls
 
 
 -- | Server IP addresses information.
@@ -178,6 +180,7 @@ instance ADC.HasCodec ServerIpInfo where
             <*> ADC.requiredField "private_ipv6" "Private IPv6 addresses." ADC..= _serverIpInfoPrivateIpv6
 
 
+-- | Data definition for object buckets.
 data ObjectBucket = ObjectBucket
   { _objectBucketName :: !T.Text
   , _objectBucketProvider :: !Provider
@@ -199,3 +202,71 @@ instance ADC.HasCodec ObjectBucket where
             <*> ADC.requiredField "provider" "Cloud provider." ADC..= _objectBucketProvider
             <*> ADC.requiredField "product" "Product name." ADC..= _objectBucketProduct
             <*> ADC.optionalField "created_at" "Creation timestamp." ADC..= _objectBucketCreatedAt
+
+
+-- | Data definition for firewall configuration.
+data Firewall = Firewall
+  { _firewallId :: !T.Text
+  , _firewallName :: !(Maybe T.Text)
+  , _firewallRulesInbound :: ![FirewallRule]
+  , _firewallRulesOutbound :: ![FirewallRule]
+  , _firewallCreatedAt :: !(Maybe Time.UTCTime)
+  }
+  deriving (Eq, Generic, Show)
+  deriving (Aeson.FromJSON, Aeson.ToJSON) via (ADC.Autodocodec Firewall)
+
+
+instance ADC.HasCodec Firewall where
+  codec =
+    _codec ADC.<?> "Firewall"
+    where
+      _codec =
+        ADC.object "Firewall" $
+          Firewall
+            <$> ADC.requiredField "id" "Firewall ID." ADC..= _firewallId
+            <*> ADC.optionalField "name" "Firewall name." ADC..= _firewallName
+            <*> ADC.requiredField "rules_inbound" "Inbound rules." ADC..= _firewallRulesInbound
+            <*> ADC.requiredField "rules_outbound" "Outbound rules." ADC..= _firewallRulesOutbound
+            <*> ADC.optionalField "created_at" "Creation timestamp." ADC..= _firewallCreatedAt
+
+
+-- | Data definition for firewall rule.
+data FirewallRule = FirewallRule
+  { _firewallRuleProtocol :: !T.Text
+  , _firewallRulePorts :: ![FirewallRulePorts]
+  , _firewallRuleEntities :: ![T.Text]
+  }
+  deriving (Eq, Generic, Show)
+  deriving (Aeson.FromJSON, Aeson.ToJSON) via (ADC.Autodocodec FirewallRule)
+
+
+instance ADC.HasCodec FirewallRule where
+  codec =
+    _codec ADC.<?> "Firewall Rule"
+    where
+      _codec =
+        ADC.object "FirewallRule" $
+          FirewallRule
+            <$> ADC.requiredField "protocol" "Protocol." ADC..= _firewallRuleProtocol
+            <*> ADC.requiredField "ports" "Ports." ADC..= _firewallRulePorts
+            <*> ADC.requiredField "entities" "Sources or destinations." ADC..= _firewallRuleEntities
+
+
+-- | Data definition for firewall rule ports.
+data FirewallRulePorts = FirewallRulePorts
+  { _firewallRulePortsFrom :: !Int32
+  , _firewallRulePortsTo :: !Int32
+  }
+  deriving (Eq, Generic, Show)
+  deriving (Aeson.FromJSON, Aeson.ToJSON) via (ADC.Autodocodec FirewallRulePorts)
+
+
+instance ADC.HasCodec FirewallRulePorts where
+  codec =
+    _codec ADC.<?> "Firewall Rule Ports"
+    where
+      _codec =
+        ADC.object "FirewallRulePorts" $
+          FirewallRulePorts
+            <$> ADC.requiredField "from" "From port." ADC..= _firewallRulePortsFrom
+            <*> ADC.requiredField "to" "To port." ADC..= _firewallRulePortsTo


### PR DESCRIPTION
This is not my proudest commit.

Firewall definitions are quite diverse across providers. There are caveats for individual providers, too.

I am pretty sure that we can find a compact/concise data definition for representing such diversity, but not today.

For now, I am proceeding with this dirty implementation. It should do the job.
