### PR TITLE
Fix Static Build

### DIFF
--- a/build-static.sh
+++ b/build-static.sh
@@ -12,7 +12,7 @@ set -eo pipefail
 ## `--enable-executable-stripping`, hence the `strip` command usage.
 
 ## GHC version:
-GHC_VERSION="9.6.5"
+GHC_VERSION="9.6.6"
 
 ## Docker image:
 DOCKER_IMAGE="quay.io/benz0li/ghc-musl:${GHC_VERSION}"

--- a/build-static.sh
+++ b/build-static.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+## Fail on errors including pipe failures:
+set -eo pipefail
+
 ## NOTE: Things would be much easier if we could use Nix, but we can
 ## not (or I find it rather tedious). So, we have to use Docker.
 ##


### PR DESCRIPTION
- **chore(build): fail on errors during script execution**
- **fix(build): fix GHC version of static builder**
