### PR TITLE
Switch to NixOS Unstable (GHC v9.8.4)

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -3,3 +3,32 @@ packages:
 
 package *
   ghc-options: -fwrite-ide-info
+
+-- BEGIN WORKAROUND
+--
+-- This workaround is needed to avoid duplicate record field errors on amazonka
+-- libraries as per migration to GHC 9.8.4.
+--
+-- Once all amazonka libraries are updated for GHC 9.8 and/or later, we can
+-- remove this workaround.
+package amazonka-ec2
+  ghc-options: -XDuplicateRecordFields
+
+package amazonka-lightsail
+  ghc-options: -XDuplicateRecordFields
+
+package amazonka-route53
+  ghc-options: -XDuplicateRecordFields
+
+package amazonka-s3
+  ghc-options: -XDuplicateRecordFields
+
+package amazonka-sso
+  ghc-options: -XDuplicateRecordFields
+
+package amazonka-sts
+  ghc-options: -XDuplicateRecordFields
+
+package amazonka
+  ghc-options: -XDuplicateRecordFields
+-- END WORKAROUND

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751274312,
-        "narHash": "sha256-/bVBlRpECLVzjV19t5KMdMFWSwKLtb5RyXdjz3LJT+g=",
+        "lastModified": 1755027561,
+        "narHash": "sha256-IVft239Bc8p8Dtvf7UAACMG5P3ZV+3/aO28gXpGtMXI=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "50ab793786d9de88ee30ec4e4c24fb4236fc2674",
+        "rev": "005433b926e16227259a1843015b5b2b7f7d1fc3",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.11",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "clompse - Patrol Cloud Resources";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
   };
 


### PR DESCRIPTION
This required some hacks and workarounds for static builds.
